### PR TITLE
Update doc to be consistent with output of bio_process.

### DIFF
--- a/neurokit/signal/events.py
+++ b/neurokit/signal/events.py
@@ -249,7 +249,7 @@ def plot_events_in_signal(signal, events, color="red"):
     ----------
     >>> import neurokit as nk
     >>> df = nk.bio_process(ecg=signal, sampling_rate=1000)
-    >>> events = df["ECG"]["Rpeaks"]
+    >>> events = df["ECG"]["R_Peaks"]
     >>> plot_events_in_signal(signal, events)
 
     Notes


### PR DESCRIPTION
Example lines could be run as is since the key in `nk.bio_process()['ECG']` is actually `R_Peaks` and not `Rpeaks`:^. Fixed this.