### PR TITLE
Allow ecg_hrv to take either RPeaks or RRis as argument

### DIFF
--- a/neurokit/bio/bio_ecg.py
+++ b/neurokit/bio/bio_ecg.py
@@ -481,10 +481,10 @@ def ecg_hrv(rpeaks=None, rri=None, sampling_rate=1000, hrv_features=["time", "fr
     """
     # Check arguments: exactly one of rpeaks or rri has to be given as input
     if rpeaks is None and rri is None:
-        raise ValueError("rpeaks or rri needs to be given.")
+        raise ValueError("Eiher rpeaks or RRIs needs to be given.")
 
     if rpeaks is not None and rri is not None:
-        raise ValueError("Either rpeaks or RRI should be given but not both.")
+        raise ValueError("Either rpeaks or RRIs should be given but not both.")
 
     # Initialize empty dict
     hrv = {}

--- a/neurokit/signal/complexity.py
+++ b/neurokit/signal/complexity.py
@@ -522,7 +522,7 @@ def complexity_entropy_spectral(signal, sampling_rate, bands=None):
         List or array of values.
     sampling_rate : int
         Sampling rate (samples/second).
-    bands : int
+    bands : list or array
         A list of numbers delimiting the bins of the frequency bands. If None the entropy is computed over the whole range of the DFT (from 0 to `f_s/2`).
 
     Returns


### PR DESCRIPTION
Sorry for the delay, this was actually ready for a long time but I just discovered I only had the change locally.
It simply offers the option to pass either RPeaks or RRIs to the `ecg_hrv` function, instead of imposing to pass the rpeaks.