### PR TITLE
converting eda to double

### DIFF
--- a/neurokit/bio/bio_eda.py
+++ b/neurokit/bio/bio_eda.py
@@ -238,8 +238,9 @@ def cvxEDA(eda, sampling_rate=1000, tau0=2., tau1=0.7, delta_knot=10., alpha=8e-
     # Normalizing signal
     eda = z_score(eda)
     eda = np.array(eda)[:,0]
-
+    
     n = len(eda)
+    eda = eda.astype('double')
     eda = cv.matrix(eda)
 
     # bateman ARMA model


### PR DESCRIPTION
As explained in https://stackoverflow.com/questions/33423081/converting-numpy-vector-to-cvxopt , 
cv.matrix function only accepts double type. It raises an error when using eda signal containing float type.