### PR TITLE
Removing double rescaling in ecg_hrv()

### DIFF
--- a/neurokit/bio/bio_ecg.py
+++ b/neurokit/bio/bio_ecg.py
@@ -576,8 +576,7 @@ def ecg_hrv(rpeaks=None, rri=None, sampling_rate=1000, hrv_features=["time", "fr
             print("NeuroKit Warning: ecg_hrv(): Sequence too short to compute interpolation. Will skip many features.")
             return(hrv)
 
-        # Rescale to 1000Hz
-        RRi = RRi*1000
+
         hrv["df"] = RRi.to_frame("ECG_RR_Interval")  # Continuous (interpolated) signal of RRi
 
 


### PR DESCRIPTION
Double rescaling of RRi already done at L533, causing "ECG_RR_Interval" units to be in microseconds units instead of milliseconds, and possibly resulting in scale errors in "frequency" and "non-linear" features.