### PR TITLE
Fix #101 by importing joblib package rather than sklearn.externals version

### DIFF
--- a/neurokit/bio/bio_ecg.py
+++ b/neurokit/bio/bio_ecg.py
@@ -9,6 +9,7 @@ import nolds
 import mne
 import biosppy
 import scipy.signal
+import joblib
 
 from .bio_ecg_preprocessing import *
 from .bio_rsp import *
@@ -354,9 +355,8 @@ def ecg_signal_quality(cardiac_cycles, sampling_rate, rpeaks=None, quality_model
     cardiac_cycles = np.array(cardiac_cycles)
 
     if quality_model == "default":
-        model = sklearn.externals.joblib.load(Path.materials() + 'heartbeat_classification.model')
-    else:
-        model = sklearn.externals.joblib.load(quality_model)
+        quality_model = Path.materials() + 'heartbeat_classification.model'
+    model = joblib.load(quality_model)
 
     # Initialize empty dict
     quality = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ cvxopt
 nose
 coverage
 pytest
+joblib


### PR DESCRIPTION
The sklearn.externals.joblib module was deprecated in favor of a dependency on joblib - see Miscellaneous section in 0.21 changelog: https://scikit-learn.org/stable/whats_new/v0.21.html#changelog )

This PR removes sklearn.externals.joblib and uses the external joblib module instead. Fixes issue #101.